### PR TITLE
[ refactor ] Move `invnormcdf` and impls to separate modules

### DIFF
--- a/src/Statistics/Confidence.idr
+++ b/src/Statistics/Confidence.idr
@@ -6,8 +6,10 @@ import Data.DPair
 import public Data.Nat
 import public Data.Vect
 
-import Statistics.Erf
+import public Statistics.Norm.Rough
 import public Statistics.Probability
+
+-- This module reexports the rough implementation for `InvNormCDF` for compatility reasons, this may be changed in the future
 
 %default total
 
@@ -15,6 +17,7 @@ import public Statistics.Probability
 -- https://en.wikipedia.org/wiki/Binomial_proportion_confidence_interval#Wilson_score_interval
 export
 wilsonBounds :
+  InvNormCDF =>
   (confidence : Probability) ->
   (count : Nat) ->
   (0 _ : IsSucc count) =>
@@ -110,6 +113,7 @@ DefaultConfidence = 1/1000000000
 export
 checkCoverageConditions :
   TraversableSt t =>
+  InvNormCDF =>
   {default DefaultConfidence confidence : Probability} ->
   Vect n (CoverageTest a) ->
   t a ->
@@ -141,6 +145,7 @@ checkCoverageConditions coverageTests = mapSt checkCoverageOnce initialResults w
 export %inline
 checkCoverageCondition :
   TraversableSt t =>
+  InvNormCDF =>
   {default DefaultConfidence confidence : Probability} ->
   CoverageTest a ->
   t a ->

--- a/src/Statistics/Erf.idr
+++ b/src/Statistics/Erf.idr
@@ -1,5 +1,6 @@
 module Statistics.Erf
 
+import public Statistics.Norm
 import public Statistics.Probability
 
 %default total
@@ -17,88 +18,10 @@ export
 erf : SolidDouble -> DoubleBetween (-1) 1
 erf x = 1 - erfc x
 
--- Code below is based on taken from
--- https://hackage.haskell.org/package/erf-2.0.0.0/docs/src/Data-Number-Erf.html
--- Licensed with BSD-3-Clause, copyright Lennart Augustsson
-
 export
-normcdf : SolidDouble -> Probability
-normcdf x = P $ erfc (-x / sqrt 2) / 2
-
--- calculation with precision only up to 10^9
--- this implementation does not require error function implementation (which now is implemented through a `%foreign` function)
-export
-invnormcdf' : Probability -> SolidDouble
-invnormcdf' p =
-    let res = if      p == 0       then NegInf
-              else if p == 1       then PosInf
-              else if p < pLow     then closeToLowBound p
-              else if p.inv < pLow then - closeToLowBound p.inv
-              else                      middling p
-    in roughlyFit res
-
-  where
-    pLow : Probability
-    pLow = 0.02425
-
-    closeToLowBound : Probability -> Double
-    closeToLowBound p = let
-      c1 = -7.784894002430293e-03
-      c2 = -3.223964580411365e-01
-      c3 = -2.400758277161838e+00
-      c4 = -2.549732539343734e+00
-      c5 =  4.374664141464968e+00
-      c6 =  2.938163982698783e+00
-
-      d1 =  7.784695709041462e-03
-      d2 =  3.224671290700398e-01
-      d3 =  2.445134137142996e+00
-      d4 =  3.754408661907416e+00
-
-      q = sqrt(-2*log(p.asDouble))
-
-      in (((((c1*q+c2)*q+c3)*q+c4)*q+c5)*q+c6) /
-         ((((d1*q+d2)*q+d3)*q+d4)*q+1)
-
-    %inline
-    middling : Probability -> Double
-    middling p = let
-      a1 = -3.969683028665376e+01
-      a2 =  2.209460984245205e+02
-      a3 = -2.759285104469687e+02
-      a4 =  1.383577518672690e+02
-      a5 = -3.066479806614716e+01
-      a6 =  2.506628277459239e+00
-
-      b1 = -5.447609879822406e+01
-      b2 =  1.615858368580409e+02
-      b3 = -1.556989798598866e+02
-      b4 =  6.680131188771972e+01
-      b5 = -1.328068155288572e+01
-
-      q = p.asDouble - 0.5
-      r = q*q
-
-      in (((((a1*r+a2)*r+a3)*r+a4)*r+a5)*r+a6)*q /
-         (((((b1*r+b2)*r+b3)*r+b4)*r+b5)*r+1)
-
-export
-invnormcdf : Probability -> SolidDouble
-invnormcdf p =
-  if      p == 0 then NegInf
-  else if p == 1 then PosInf
-  else let -- Do one iteration with Halley's root finder to get a more accurate result.
-    x = invnormcdf' p
-    e = (normcdf x).asDouble - p.asDouble
-    x = x.asDouble
-    u = e * sqrt (2*pi) * exp (x*x / 2)
-    x' = x - u / (1 + x * u / 2)
-    in roughlyFit x'
-
-export
-inverfc : DoubleBetween 0 2 -> SolidDouble
+inverfc : InvNormCDF => DoubleBetween 0 2 -> SolidDouble
 inverfc p = - invnormcdf (P $ p/2) / sqrt 2
 
 export
-inverf : DoubleBetween (-1) 1 -> SolidDouble
+inverf : InvNormCDF => DoubleBetween (-1) 1 -> SolidDouble
 inverf p = inverfc (1 - p)

--- a/src/Statistics/Norm.idr
+++ b/src/Statistics/Norm.idr
@@ -1,0 +1,16 @@
+||| Stuff related to the normal distribution
+module Statistics.Norm
+
+import public Statistics.Probability
+
+%default total
+
+||| Cumulative distribution function (CDF) of the normal distribution
+public export
+interface NormCDF where
+  normcdf : SolidDouble -> Probability
+
+||| Inverse cumulative distribution function of the normal distribution
+public export
+interface InvNormCDF where
+  invnormcdf : Probability -> SolidDouble

--- a/src/Statistics/Norm/Precise.idr
+++ b/src/Statistics/Norm/Precise.idr
@@ -1,0 +1,28 @@
+module Statistics.Norm.Precise
+
+import Statistics.Erf
+import public Statistics.Norm
+import Statistics.Norm.Rough
+
+%default total
+
+export
+NormCDF where
+  normcdf x = P $ erfc (-x / sqrt 2) / 2
+
+-- theoretically, it can get rough `InvNormCDF` as an auto-implicit, i.e. to improve any implementation
+export
+InvNormCDF where
+  -- Code below is based on taken from
+  -- https://hackage.haskell.org/package/erf-2.0.0.0/docs/src/Data-Number-Erf.html
+  -- Licensed with BSD-3-Clause, copyright Lennart Augustsson
+  invnormcdf p =
+    if      p == 0 then NegInf
+    else if p == 1 then PosInf
+    else let -- Do one iteration with Halley's root finder to get a more accurate result.
+      x = invnormcdf @{Rough} p
+      e = (normcdf x).asDouble - p.asDouble
+      x = x.asDouble
+      u = e * sqrt (2*pi) * exp (x*x / 2)
+      x' = x - u / (1 + x * u / 2)
+      in roughlyFit x'

--- a/src/Statistics/Norm/Rough.idr
+++ b/src/Statistics/Norm/Rough.idr
@@ -1,0 +1,67 @@
+module Statistics.Norm.Rough
+
+import public Statistics.Norm
+
+%default total
+
+||| Calculation of the inverse of CDF for normal distribution with precision only up to 10^9.
+||| This implementation does not have any external dependencies.
+export %defaulthint
+Rough : InvNormCDF
+Rough = R where
+  -- Code below is based on taken from
+  -- https://hackage.haskell.org/package/erf-2.0.0.0/docs/src/Data-Number-Erf.html
+  -- Licensed with BSD-3-Clause, copyright Lennart Augustsson
+  [R] InvNormCDF where
+    invnormcdf p =
+        let res = if      p == 0       then NegInf
+                  else if p == 1       then PosInf
+                  else if p < pLow     then closeToLowBound p
+                  else if p.inv < pLow then - closeToLowBound p.inv
+                  else                      middling p
+        in roughlyFit res
+
+      where
+        pLow : Probability
+        pLow = 0.02425
+
+        closeToLowBound : Probability -> Double
+        closeToLowBound p = let
+          c1 = -7.784894002430293e-03
+          c2 = -3.223964580411365e-01
+          c3 = -2.400758277161838e+00
+          c4 = -2.549732539343734e+00
+          c5 =  4.374664141464968e+00
+          c6 =  2.938163982698783e+00
+
+          d1 =  7.784695709041462e-03
+          d2 =  3.224671290700398e-01
+          d3 =  2.445134137142996e+00
+          d4 =  3.754408661907416e+00
+
+          q = sqrt(-2*log(p.asDouble))
+
+          in (((((c1*q+c2)*q+c3)*q+c4)*q+c5)*q+c6) /
+             ((((d1*q+d2)*q+d3)*q+d4)*q+1)
+
+        %inline
+        middling : Probability -> Double
+        middling p = let
+          a1 = -3.969683028665376e+01
+          a2 =  2.209460984245205e+02
+          a3 = -2.759285104469687e+02
+          a4 =  1.383577518672690e+02
+          a5 = -3.066479806614716e+01
+          a6 =  2.506628277459239e+00
+
+          b1 = -5.447609879822406e+01
+          b2 =  1.615858368580409e+02
+          b3 = -1.556989798598866e+02
+          b4 =  6.680131188771972e+01
+          b5 = -1.328068155288572e+01
+
+          q = p.asDouble - 0.5
+          r = q*q
+
+          in (((((a1*r+a2)*r+a3)*r+a4)*r+a5)*r+a6)*q /
+             (((((b1*r+b2)*r+b3)*r+b4)*r+b5)*r+1)

--- a/summary-stat.ipkg
+++ b/summary-stat.ipkg
@@ -13,6 +13,9 @@ modules
 
   , Statistics.Confidence
   , Statistics.Erf
+  , Statistics.Norm
+  , Statistics.Norm.Precise
+  , Statistics.Norm.Rough
   , Statistics.Probability
 
 sourcedir = "src"

--- a/tests/Tests.idr
+++ b/tests/Tests.idr
@@ -5,6 +5,7 @@ import Test.Golden.RunnerHelper
 main : IO ()
 main = goldenRunner
   [ "Error function" `atDir` "error-function"
+  , "Normal distribution CDF" `atDir` "norm-cdf"
   , "Probability type" `atDir` "probability"
   , "Confidence interval" `atDir` "confidence-interval"
   ]

--- a/tests/confidence-interval/believeme001/BelieveMeSpec.idr
+++ b/tests/confidence-interval/believeme001/BelieveMeSpec.idr
@@ -3,13 +3,15 @@ module BelieveMeSpec
 import Hedgehog
 
 import Statistics.Confidence
+import Statistics.Norm.Rough
+import Statistics.Norm.Precise
 
 import Test.Common
 
 MaxWilsonCount : Nat
 MaxWilsonCount = 1000000
 
-wilsonBounds_corr : Property
+wilsonBounds_corr : InvNormCDF => Property
 wilsonBounds_corr = property $ do
   confidence <- forAll anyProbability
   count' <- forAll $ nat $ constant 0 MaxWilsonCount
@@ -38,6 +40,7 @@ main : IO ()
 main = test
   [ "believe_me" `MkGroup`
       [ ("wilsonBounds", wilsonBounds_corr)
+      , ("wilsonBounds @{Rough}", wilsonBounds_corr @{Rough})
       , ("coverBetween", coverBetween_corr)
       ]
   ]

--- a/tests/confidence-interval/believeme001/expected
+++ b/tests/confidence-interval/believeme001/expected
@@ -1,4 +1,5 @@
 ━━━ believe_me ━━━
   ✓ wilsonBounds passed 10000 tests.
+  ✓ wilsonBounds @{Rough} passed 10000 tests.
   ✓ coverBetween passed 10000 tests.
-  ✓ 2 succeeded.
+  ✓ 3 succeeded.

--- a/tests/confidence-interval/values001/WilsonSpec.idr
+++ b/tests/confidence-interval/values001/WilsonSpec.idr
@@ -6,6 +6,8 @@ import Hedgehog
 import Hedgehog.Internal.Property.Hack
 
 import Statistics.Confidence
+import Statistics.Norm.Precise
+import Statistics.Norm.Rough
 
 import Test.Common
 
@@ -15,7 +17,7 @@ MaxCount = 1000000000000
 AcceptanceTolerance : Double
 AcceptanceTolerance = 1.0e-15
 
-wilsonBounds_asHedgehog : Property
+wilsonBounds_asHedgehog : InvNormCDF => Property
 wilsonBounds_asHedgehog = property $ do
   count      <- forAll $ nat $ constant 1 MaxCount
   positives  <- forAll $ nat $ constant 0 count
@@ -32,6 +34,7 @@ wilsonBounds_asHedgehog = property $ do
                                              (P $ BoundedDouble acceptance @{believe_me Oh} @{believe_me Oh})
                                              count
                                              (ratio positives count @{believe_me LTEZero} @{believe_me ItIsSucc})
+                                             @{%search}
                                              @{believe_me ItIsSucc}
 
   annotate "from Hedgehog: \{show fromHedgehog}"
@@ -44,7 +47,7 @@ wilsonBounds_asHedgehog = property $ do
   diff (fst fromHedgehog) eqUpToEps (fst fromSummaryStat)
   diff (snd fromHedgehog) eqUpToEps (snd fromSummaryStat)
 
-wilsonBounds_low_leq_high : Property
+wilsonBounds_low_leq_high : InvNormCDF => Property
 wilsonBounds_low_leq_high = property $ do
   count      <- forAll $ nat $ constant 1 MaxCount
   positives  <- forAll $ nat $ constant 0 count
@@ -58,6 +61,7 @@ wilsonBounds_low_leq_high = property $ do
                                       (P $ BoundedDouble acceptance @{believe_me Oh} @{believe_me Oh})
                                       count
                                       (ratio positives count @{believe_me $ LTEZero {right=Z}} @{believe_me $ ItIsSucc {n=1}})
+                                      @{%search}
                                       @{believe_me $ ItIsSucc {n=1}}
 
   annotate "from summary-stat: \{show (lo, hi)}"
@@ -69,5 +73,9 @@ main = test
   [ "Wilson bounds" `MkGroup`
       [ ("as in hedgehog", wilsonBounds_asHedgehog)
       , ("low <= high", wilsonBounds_low_leq_high)
+      ]
+  , "Wilson bounds @{Rough}" `MkGroup`
+      [ ("as in hedgehog", wilsonBounds_asHedgehog @{Rough})
+      , ("low <= high", wilsonBounds_low_leq_high @{Rough})
       ]
   ]

--- a/tests/confidence-interval/values001/expected
+++ b/tests/confidence-interval/values001/expected
@@ -2,3 +2,7 @@
   ✓ as in hedgehog passed 10000 tests.
   ✓ low <= high passed 10000 tests.
   ✓ 2 succeeded.
+━━━ Wilson bounds @{Rough} ━━━
+  ✓ as in hedgehog passed 10000 tests.
+  ✓ low <= high passed 10000 tests.
+  ✓ 2 succeeded.

--- a/tests/error-function/believeme001/BelieveMeSpec.idr
+++ b/tests/error-function/believeme001/BelieveMeSpec.idr
@@ -3,6 +3,8 @@ module BelieveMeSpec
 import Hedgehog
 
 import Statistics.Erf
+import Statistics.Norm.Precise
+import Statistics.Norm.Rough
 
 import Test.Common
 
@@ -10,12 +12,12 @@ main : IO ()
 main = test
   [ "believe_me" `MkGroup`
       [ ("erfc bounds", un_corr erfc)
-      , ("invnormcdf", un_corr invnormcdf)
       ]
   , "other bounds" `MkGroup`
       [ ("erf", un_corr erf)
-      , ("normcdf", un_corr normcdf)
       , ("inverfc", un_corr inverfc)
+      , ("inverfc @{Rough}", un_corr $ inverfc @{Rough})
       , ("inverf", un_corr inverf)
+      , ("inverf @{Rough}", un_corr $ inverf @{Rough})
       ]
   ]

--- a/tests/error-function/believeme001/expected
+++ b/tests/error-function/believeme001/expected
@@ -1,10 +1,10 @@
 ━━━ believe_me ━━━
   ✓ erfc bounds passed 10000 tests.
-  ✓ invnormcdf passed 10000 tests.
-  ✓ 2 succeeded.
+  ✓ 1 succeeded.
 ━━━ other bounds ━━━
   ✓ erf passed 10000 tests.
-  ✓ normcdf passed 10000 tests.
   ✓ inverfc passed 10000 tests.
+  ✓ inverfc @{Rough} passed 10000 tests.
   ✓ inverf passed 10000 tests.
-  ✓ 4 succeeded.
+  ✓ inverf @{Rough} passed 10000 tests.
+  ✓ 5 succeeded.

--- a/tests/error-function/inversions001/expected
+++ b/tests/error-function/inversions001/expected
@@ -1,10 +1,16 @@
 ━━━ inversions ━━━
   ✓ erf passed 10000 tests.
   ✓ erfc passed 10000 tests.
-  ✓ normcdf passed 10000 tests.
-  ✓ 3 succeeded.
+  ✓ 2 succeeded.
 ━━━ anti-inversions ━━━
   ✓ erf passed 10000 tests.
   ✓ erfc passed 10000 tests.
-  ✓ normcdf passed 10000 tests.
-  ✓ 3 succeeded.
+  ✓ 2 succeeded.
+━━━ inversions @{Rough} ━━━
+  ✓ erf passed 10000 tests.
+  ✓ erfc passed 10000 tests.
+  ✓ 2 succeeded.
+━━━ anti-inversions @{Rough} ━━━
+  ✓ erf passed 10000 tests.
+  ✓ erfc passed 10000 tests.
+  ✓ 2 succeeded.

--- a/tests/norm-cdf/believeme001/BelieveMeSpec.idr
+++ b/tests/norm-cdf/believeme001/BelieveMeSpec.idr
@@ -1,0 +1,16 @@
+module BelieveMeSpec
+
+import Hedgehog
+
+import Statistics.Norm.Precise
+import Statistics.Norm.Rough
+
+import Test.Common
+
+main : IO ()
+main = test
+  [ "believe_me" `MkGroup`
+      [ ("invnormcdf", un_corr invnormcdf)
+      , ("invnormcdf @{Rough}", un_corr $ invnormcdf @{Rough})
+      ]
+  ]

--- a/tests/norm-cdf/believeme001/expected
+++ b/tests/norm-cdf/believeme001/expected
@@ -1,0 +1,4 @@
+━━━ believe_me ━━━
+  ✓ invnormcdf passed 10000 tests.
+  ✓ invnormcdf @{Rough} passed 10000 tests.
+  ✓ 2 succeeded.

--- a/tests/norm-cdf/believeme001/run
+++ b/tests/norm-cdf/believeme001/run
@@ -1,0 +1,6 @@
+rm -rf build/
+
+flock "$1" pack -q install-deps test.ipkg && \
+pack -q run test.ipkg -n 10000
+
+rm -rf build/

--- a/tests/norm-cdf/believeme001/test.ipkg
+++ b/tests/norm-cdf/believeme001/test.ipkg
@@ -1,0 +1,9 @@
+package a-summary-stat-test
+
+depends = summary-stat
+        , hedgehog
+        , common-definitions-for-tests
+
+main = BelieveMeSpec
+
+executable = test

--- a/tests/norm-cdf/inversions001/InversionSpec.idr
+++ b/tests/norm-cdf/inversions001/InversionSpec.idr
@@ -1,0 +1,43 @@
+module InversionSpec
+
+import Hedgehog
+
+import Statistics.Norm.Precise
+import Statistics.Norm.Rough
+
+import Test.Common
+
+namespace Forward
+
+  domainLimit : Double
+  domainLimit = 3
+
+  inormDouble : Gen SolidDouble
+  inormDouble = relaxToSolid <$> anyBoundedDouble (-domainLimit) domainLimit
+
+  export
+  normcdf_inv_corr : Eps => InvNormCDF => Property
+  normcdf_inv_corr = property $ do
+    x <- forAll inormDouble
+    annotateShow $ normcdf x
+    diff (invnormcdf $ normcdf x) eqUpToEps x
+
+namespace Backward
+
+  export
+  inv_normcdf_corr : Eps => InvNormCDF => Property
+  inv_normcdf_corr = property $ do
+    x <- forAll anyProbability
+    diff (normcdf $ invnormcdf x) eqUpToEps x
+
+main : IO ()
+main = test
+  [ "inversions" `MkGroup`
+      [ ("normcdf", normcdf_inv_corr @{MkEps 1.0e-11})
+      , ("normcdf @{Rough}", normcdf_inv_corr  @{MkEps 1.0e-8} @{Rough})
+      ]
+  , "anti-inversions" `MkGroup`
+      [ ("normcdf", inv_normcdf_corr @{MkEps 1.0e-15})
+      , ("normcdf @{Rough}", inv_normcdf_corr  @{MkEps 1.0e-9} @{Rough})
+      ]
+  ]

--- a/tests/norm-cdf/inversions001/expected
+++ b/tests/norm-cdf/inversions001/expected
@@ -1,0 +1,8 @@
+━━━ inversions ━━━
+  ✓ normcdf passed 10000 tests.
+  ✓ normcdf @{Rough} passed 10000 tests.
+  ✓ 2 succeeded.
+━━━ anti-inversions ━━━
+  ✓ normcdf passed 10000 tests.
+  ✓ normcdf @{Rough} passed 10000 tests.
+  ✓ 2 succeeded.

--- a/tests/norm-cdf/inversions001/run
+++ b/tests/norm-cdf/inversions001/run
@@ -1,0 +1,6 @@
+rm -rf build/
+
+flock "$1" pack -q install-deps test.ipkg && \
+pack -q run test.ipkg -n 10000
+
+rm -rf build/

--- a/tests/norm-cdf/inversions001/test.ipkg
+++ b/tests/norm-cdf/inversions001/test.ipkg
@@ -1,0 +1,9 @@
+package a-summary-stat-test
+
+depends = summary-stat
+        , hedgehog
+        , common-definitions-for-tests
+
+main = InversionSpec
+
+executable = test


### PR DESCRIPTION
Now, to be able to use `invnormcdf`, one needs to import `Statistics.Norm` and to have a `InvNormCDF =>` auto-implicit parameter. There are two implementations, rough one in module `Statistics.Norm.Rough`, this implementation does not require dependency on the foreign C library. Precise implementation is in `Statistics.Norm.Precise` and requires foreign `libm` library.

If both modules with implementations are imported, precise one takes precedence. `Statistics.Confidence` uses the rough implementation by default.

This PR increases portability of the library, since only those who imports `Statistics.Norm.Precise` really depend on the `%foreign` implementation of `erfc`.